### PR TITLE
add srfi-lite-lib to deps

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,9 +1,9 @@
 #lang info
 (define collection "kodictl")
 (define deps '("base"
-               "rackunit-lib"
+	       "srfi-lite-lib"
 	       "json-rpc-client"))
-(define build-deps '("scribble-lib" "racket-doc"))
+(define build-deps '("scribble-lib" "racket-doc" "rackunit-lib"))
 (define scribblings '(("scribblings/kodictl.scrbl" ())))
 (define pkg-desc "Command-line interface for the Kodi JSON-RPC")
 (define version "0.1")


### PR DESCRIPTION
```
kodictl/action.rkt:4:9: collection not found
  for module path: srfi/13
  collection: "srfi"
  in collection directories:
   /root/.racket/6.6/collects
   /usr/share/racket/collects
   /root/.racket/6.6/pkgs/rackunit
   /root/.racket/6.6/pkgs/rackunit-lib
   /usr/share/racket/pkgs/racket-lib
  context...:
   show-collection-err
   standard-module-name-resolver
   standard-module-name-resolver
   standard-module-name-resolver
   standard-module-name-resolver
```

```
raco pkg install srfi-lite-lib --deps force
```
