### PR TITLE
install json-rpc-client from github

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -2,7 +2,7 @@
 (define collection "kodictl")
 (define deps '("base"
 	       "srfi-lite-lib"
-	       "json-rpc-client"))
+	       "https://github.com/vdloo/json-rpc-client.git"))
 (define build-deps '("scribble-lib" "racket-doc" "rackunit-lib"))
 (define scribblings '(("scribblings/kodictl.scrbl" ())))
 (define pkg-desc "Command-line interface for the Kodi JSON-RPC")


### PR DESCRIPTION
To make `raco pkg install` work out of the box and also install
json-rpc-client. This fixes https://github.com/vdloo/kodictl/issues/9

The dependency previously had to be manually installed by running `raco
pkg install` in the https://github.com/vdloo/json-rpc-client repo, but
raco can install this just fine from github directly as well:

```
$ raco pkg install
Linking current directory as a package
The following uninstalled packages are listed as dependencies of kodictl:
   https://github.com/vdloo/json-rpc-client.git
Would you like to install these dependencies? [Y/n/a/c/?] Y
Querying Git references for json-rpc-client at https://github.com/vdloo/json-rpc-client.git
Downloading repository https://github.com/vdloo/json-rpc-client.git
```

Still works after all these years too, that's pretty cool. I don't use
this anymore but I just tested with the latest Kodi on Archlinux and it
still manages to talk to the API succesfully.

```
$ racket main.rkt list | tail -n 5
VideoLibrary.Export : Exports all items from the video library
Playlist.GetProperties : Retrieves the values of the given properties
VideoLibrary.SetMusicVideoDetails : Update the given music video with the given details
GUI.GetStereoscopicModes : Returns the supported stereoscopic modes of the GUI
PVR.GetBroadcastDetails : Retrieves the details of a specific broadcast

$ racket main.rkt notify title "The message to display"
'#hasheq((id . 1) (jsonrpc . "2.0") (result . "OK"))
```

Tested against:
```
$ kodi --version
19.2 (19.2.0) Git:20211020-nogitfound Media Center Kodi
```